### PR TITLE
fix: implement defensive bounds checking in _processPayload to preven…

### DIFF
--- a/cipclient.py
+++ b/cipclient.py
@@ -396,21 +396,35 @@ class CIPSocketClient:
             _logger.debug("  Heartbeat")
         elif ciptype == 0x05:
             # data
+            if length < 4:
+                _logger.warning("  Data packet too short")
+                return
+
             datatype = payload[3]
 
             if datatype == 0x00:
                 # digital join
+                if length < 6:
+                    _logger.warning("  Digital join packet too short")
+                    return
                 join = (((payload[5] & 0x7F) << 8) | payload[4]) + 1
                 state = ((payload[5] & 0x80) >> 7) ^ 0x01
                 self.event_queue.put(("in", "d", join, state))
                 _logger.debug(f"  Incoming Digital Join {join:04} = {state}")
             elif datatype == 0x14:
+                # analog join
+                if length < 8:
+                    _logger.warning("  Analog join packet too short")
+                    return
                 join = ((payload[4] << 8) | payload[5]) + 1
                 value = (payload[6] << 8) + payload[7]
                 self.event_queue.put(("in", "a", join, value))
                 _logger.debug(f"  Incoming Analog Join {join:04} = {value}")
             elif datatype == 0x03:
                 # update request
+                if length < 5:
+                    _logger.warning("  Update request packet too short")
+                    return
                 update_request_type = payload[4]
                 if update_request_type == 0x00:
                     # standard update request
@@ -436,6 +450,9 @@ class CIPSocketClient:
                     _logger.debug("! We don't know what to do with this update request")
             elif datatype == 0x08:
                 # date/time
+                if length < 10:
+                    _logger.warning("  Date/time packet too short")
+                    return
                 cip_date = str(binascii.hexlify(payload[4:]), "ascii")
                 _logger.debug(
                     f"  Received date/time from control processor <"
@@ -447,6 +464,9 @@ class CIPSocketClient:
                 # unexpected data packet
                 _logger.debug("! We don't know what to do with this data")
         elif ciptype == 0x12:
+            if length < 7:
+                _logger.warning("  Serial join packet too short")
+                return
             join = ((payload[5] << 8) | payload[6]) + 1
             value = str(payload[8:], "ascii")
             self.event_queue.put(("in", "s", join, value))

--- a/tests/test_cipclient.py
+++ b/tests/test_cipclient.py
@@ -1,0 +1,49 @@
+
+import pytest
+from cipclient import CIPSocketClient
+
+@pytest.fixture
+def client():
+    return CIPSocketClient("localhost", 0x03)
+
+@pytest.mark.parametrize("ciptype, payload", [
+    (0x05, b"\x00\x00\x00"),             # ciptype 0x05, payload too short for datatype access
+    (0x05, b"\x00\x00\x00\x00\x00"),     # ciptype 0x05, datatype 0x00, payload too short for digital join
+    (0x05, b"\x00\x00\x00\x14\x00\x00\x00"), # ciptype 0x05, datatype 0x14, payload too short for analog join
+    (0x05, b"\x00\x00\x00\x03"),         # ciptype 0x05, datatype 0x03, payload too short for update request type
+    (0x05, b"\x00\x00\x00\x08\x00\x00\x00\x00\x00"), # ciptype 0x05, datatype 0x08, payload too short for date/time
+    (0x12, b"\x00\x00\x00\x00\x00\x00"), # ciptype 0x12, payload too short for serial join
+])
+def test_short_payloads_no_crash(client, ciptype, payload):
+    """Verify that short payloads do not cause IndexErrors."""
+    try:
+        client._processPayload(ciptype, payload)
+    except IndexError:
+        pytest.fail(f"IndexError raised for ciptype 0x{ciptype:02x} and payload len {len(payload)}")
+
+def test_valid_digital_join(client):
+    """Verify that a valid digital join is processed correctly (no crash, item in queue)."""
+    # ciptype 0x05, payload: [0, 0, 0, datatype=0x00, join_low=0x00, join_high=0x00]
+    # join = (0 << 8 | 0) + 1 = 1, state = (0 >> 7) ^ 1 = 1
+    client._processPayload(0x05, b"\x00\x00\x00\x00\x00\x00")
+    assert not client.event_queue.empty()
+    item = client.event_queue.get()
+    assert item == ("in", "d", 1, 1)
+
+def test_valid_analog_join(client):
+    """Verify that a valid analog join is processed correctly."""
+    # ciptype 0x05, payload: [0, 0, 0, datatype=0x14, join_high=0x00, join_low=0x01, val_high=0x04, val_low=0xd2]
+    # join = (0 << 8 | 1) + 1 = 2, value = (4 << 8 | 210) = 1234
+    client._processPayload(0x05, b"\x00\x00\x00\x14\x00\x01\x04\xd2")
+    assert not client.event_queue.empty()
+    item = client.event_queue.get()
+    assert item == ("in", "a", 2, 1234)
+
+def test_valid_serial_join(client):
+    """Verify that a valid serial join is processed correctly."""
+    # ciptype 0x12, payload: [0, 0, 0, 0, 0, join_high=0x00, join_low=0x02, 0, 'H', 'e', 'l', 'l', 'o']
+    # join = (0 << 8 | 2) + 1 = 3, value = "Hello"
+    client._processPayload(0x12, b"\x00\x00\x00\x00\x00\x00\x02\x00Hello")
+    assert not client.event_queue.empty()
+    item = client.event_queue.get()
+    assert item == ("in", "s", 3, "Hello")


### PR DESCRIPTION
…t DoS

Added length checks for CIP data, digital join, analog join, update request, date/time, and serial join packets in `_processPayload` to prevent `IndexError` when processing malformed or truncated packets. This eliminates a potential denial of service vulnerability where the receive thread could crash if it receives an unexpectedly short packet. Added unit tests in `tests/test_cipclient.py` to verify the fix and ensure no regressions in packet processing.